### PR TITLE
fix get_map_entries_from_cmd_buffer

### DIFF
--- a/extractor/extractor.cpp
+++ b/extractor/extractor.cpp
@@ -493,7 +493,7 @@ bool get_descriptor_set(TraceProcessor *tp, uint64_t commandBuffer, uint64_t max
 }
 
 bool get_map_entries_from_cmd_buffer(TraceProcessor *tp, uint64_t commandBuffer, uint64_t max_timestamp,
-    std::vector<vksp_specialization_map_entry> &map_entry_vector, vksp_configuration &config)
+    uint64_t min_timestamp, std::vector<vksp_specialization_map_entry> &map_entry_vector, vksp_configuration &config)
 {
     std::string query = "SELECT arg_set_id FROM slice WHERE slice.name = 'vkCmdBindPipeline' AND "
         + std::to_string(commandBuffer)
@@ -507,7 +507,9 @@ bool get_map_entries_from_cmd_buffer(TraceProcessor *tp, uint64_t commandBuffer,
 
     std::string query2 = "SELECT arg_set_id FROM slice WHERE slice.name = 'vkCreateComputePipelines-MapEntry' AND "
         + std::to_string(pipeline)
-        + " = (SELECT int_value FROM args WHERE args.arg_set_id = slice.arg_set_id AND args.key = 'debug.pipeline')";
+        + " = (SELECT int_value FROM args WHERE args.arg_set_id = slice.arg_set_id AND args.key = 'debug.pipeline') "
+          "AND slice.ts < "
+        + std::to_string(max_timestamp) + " AND slice.ts > " + std::to_string(min_timestamp);
     EXECUTE_QUERY_NO_CHECK(it2, tp, query2);
     while (it2.Next()) {
         uint64_t arg_set_id = it2.Get(0).AsLong();
@@ -521,7 +523,9 @@ bool get_map_entries_from_cmd_buffer(TraceProcessor *tp, uint64_t commandBuffer,
     std::string query3
         = "SELECT arg_set_id FROM slice WHERE slice.name = 'vkCreateComputePipelines-specialization' AND "
         + std::to_string(pipeline)
-        + " = (SELECT int_value FROM args WHERE args.arg_set_id = slice.arg_set_id AND args.key = 'debug.pipeline')";
+        + " = (SELECT int_value FROM args WHERE args.arg_set_id = slice.arg_set_id AND args.key = 'debug.pipeline') "
+          "AND slice.ts < "
+        + std::to_string(max_timestamp) + " AND slice.ts > " + std::to_string(min_timestamp);
     EXECUTE_QUERY_NO_CHECK(it3, tp, query3);
     if (it3.Next()) {
         uint64_t arg_set_id = it3.Get(0).AsLong();
@@ -630,7 +634,8 @@ int main(int argc, char **argv)
     PRINT("Min timestamp: %lu", min_timestamp);
 
     std::vector<vksp_specialization_map_entry> map_entry_vector;
-    CHECK(get_map_entries_from_cmd_buffer(tp.get(), commandBuffer, max_timestamp, map_entry_vector, config),
+    CHECK(get_map_entries_from_cmd_buffer(
+              tp.get(), commandBuffer, max_timestamp, min_timestamp, map_entry_vector, config),
         "Could not get map entries from command buffer");
     PRINT("specialization info data (size %u): '%s'", config.specializationInfoDataSize, config.specializationInfoData);
     for (auto &me : map_entry_vector) {


### PR DESCRIPTION
when the program is free and then reallocated, we can have the same pipeline.
Let's use the timestamp to make sure of what we select.