### PR TITLE
layer: fix hang on shutdown when a queue is retrieved more than once

### DIFF
--- a/layer/layer.cpp
+++ b/layer/layer.cpp
@@ -783,6 +783,9 @@ void VKAPI_CALL vksp_GetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, 
 
     gDeviceDispatch[device].GetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue);
 
+    if (QueueToThreadInfo.count(*pQueue))
+        return;
+
     QueueToDevice[*pQueue] = device;
     if (DeviceNotToTrace.count(device) == 0) {
         auto info = new ThreadInfo(device, *pQueue);


### PR DESCRIPTION
Store the `ThreadInfo` pointer directly in `QueueThreadPool` alongside its thread, rather than looking it up via `QueueToThreadInfo` during shutdown.

If `vkGetDeviceQueue` was called multiple times for the same `VkQueue` handle, `QueueToThreadInfo` would be overwritten with only the latest `ThreadInfo`. During shutdown, `vksp_DestroyDevice` would then look up the wrong `ThreadInfo` for older entries, setting stop and notifying the wrong condition variable while the actual thread remained blocked waiting on its original (never-notified) cv.

Calling `vkGetDeviceQueue` multiple times for the same queue is valid Vulkan usage The spec (`VUID-vkGetDeviceQueue-*`) places no restriction on the number of calls, since queues are created implicitly by `vkCreateDevice` and `vkGetDeviceQueue` merely retrieves a handle.